### PR TITLE
Set zephyr.board property when board is set through API

### DIFF
--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -102,8 +102,8 @@ export function boardConfFile(): vscode.Uri | undefined {
 
 export function setBoard(b: BoardTuple) {
 	board = b;
-	kEnv.update();
 	kEnv.setConfig('zephyr.board', b);
+	kEnv.update();
 }
 
 function resolveBoard(board: string, arch: string): Promise<BoardTuple> {

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -103,6 +103,7 @@ export function boardConfFile(): vscode.Uri | undefined {
 export function setBoard(b: BoardTuple) {
 	board = b;
 	kEnv.update();
+	kEnv.setConfig('zephyr.board', b);
 }
 
 function resolveBoard(board: string, arch: string): Promise<BoardTuple> {


### PR DESCRIPTION
Right now the `kconfig.zephyr.board` property isn't set when the board is passed from the main extension to this extension's `setConfig` API function.

Not sure if this is the right place to put the call; I see there is an `updateBoardConfig` function, but that's not called at any point in the flow (and would be recursive), so hopefully this is okay.